### PR TITLE
Update pipeline-info.component.html

### DIFF
--- a/src/app/webapp-common/pipelines-controller/pipeline-details/pipeline-info.component.html
+++ b/src/app/webapp-common/pipelines-controller/pipeline-details/pipeline-info.component.html
@@ -37,7 +37,7 @@
         <ng-container *ngIf="(entity?.last_metrics | keyvalue)?.length > 0; else emptyMsg">
           <ng-container *ngFor="let metric of entity.last_metrics | keyvalue">
             <div *ngFor="let variant of $any($any(metric.value) | keyvalue) | filterMonitorMetric" class="param">
-              <div class="key" [smTooltip]="$any(variant.value).metric" smShowTooltipIfEllipsis>{{$any(variant.value).metric}}/{{$any(variant.value).variant}}</div>
+              <div class="key" [smTooltip]="$any(variant.value).metric + '/' + $any(variant.value).variant" smShowTooltipIfEllipsis>{{$any(variant.value).metric}}/{{$any(variant.value).variant}}</div>
               <div class="value" [smTooltip]="$any(variant.value).value" smShowTooltipIfEllipsis>{{$any(variant.value).value}}</div>
             </div>
           </ng-container>


### PR DESCRIPTION
**Problem**
When one uses multiple metrics under the same title but of different series, the tooltip in pipeline's info card only shows the title, making it impossible to differentiate between similar metrics.
<img width="120" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/a4540e60-7555-449b-ac80-14f2424e731c">
(e.g., all of these would show `P` here).

**Solution**
Have the tooltip be a true preview of the underlying `key`, the same way that `value` is handled when overflowing the container.