### PR TITLE
bottom-up design instead of top-down

### DIFF
--- a/src/app/webapp-common/shared/services/dag-manager-unsorted.service.ts
+++ b/src/app/webapp-common/shared/services/dag-manager-unsorted.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {DagManagerService, DagModelItem} from '@ngneat/dag';
+import { DagManagerService, DagModelItem } from '@ngneat/dag';
 
 @Injectable({
   providedIn: 'root'
@@ -7,35 +7,49 @@ import {DagManagerService, DagModelItem} from '@ngneat/dag';
 export class DagManagerUnsortedService<T extends DagModelItem> extends DagManagerService<T> {
 
   override convertArrayToDagModel(itemsArray: Array<T>): Array<Array<T>> {
-    const result = [];
-    const levels = {};
+    const result: Array<Array<T>> = [];
+    const nodeLevels = new Map<number, number>();
+    const nodeChildren = new Map<number, number[]>();
 
-    const modify = (data, pid = 0, level = 0) =>
-      data
-        .filter(({ parentIds, stepId }) => {
-          if (levels[level] && levels[level].includes(stepId)) {
-            return false;
-          }
-          return parentIds.includes(pid);
-        })
-        .forEach((e) => {
-          if (!levels[level]) {
-            levels[level] = [];
-          }
-          levels[level].push(e.stepId);
+    // Initialize nodeChildren
+    itemsArray.forEach(item => {
+      item.parentIds.forEach(pid => {
+        if (!nodeChildren.has(pid)) {
+          nodeChildren.set(pid, []);
+        }
+        nodeChildren.get(pid).push(item.stepId);
+      });
+    });
 
-          if (this.findInDoubleArray(e.stepId, result) === -1) {
-            if (!result[level]) {
-              result[level] = [e];
-            } else {
-              result[level].push(e);
-            }
-          }
-
-          modify(data, e.stepId, level + 1);
+    // Function to assign levels
+    const assignLevels = (item, currentLevel) => {
+      const existingLevel = nodeLevels.get(item.stepId);
+      if (existingLevel === undefined || existingLevel < currentLevel) {
+        nodeLevels.set(item.stepId, currentLevel);
+        const parents = itemsArray.filter(i => item.parentIds.includes(i.stepId));
+        parents.forEach(parent => {
+          assignLevels(parent, currentLevel + 1);
         });
+      }
+    };
 
-    modify(itemsArray);
+    // Start from leaf nodes and work upwards
+    itemsArray.forEach(item => {
+      if (!nodeChildren.has(item.stepId)) {
+        assignLevels(item, 0);
+      }
+    });
+
+    // Sort nodes by level and position them
+    const maxLevel = Math.max(...nodeLevels.values());
+    itemsArray.forEach(item => {
+      const level = maxLevel - nodeLevels.get(item.stepId);
+      if (!result[level]) {
+        result[level] = [];
+      }
+      result[level].push(item);
+    });
+
     return result;
   }
 }


### PR DESCRIPTION
## Objective
tldr: improve visual symmetry in pipeline DAG visualization (especially for large pipelines)

> The main objective of these changes is to modify the existing DAG layout algorithm to use a bottom-up approach, ensuring that all final steps appear at the bottom level and the layout builds upwards. This change aims to improve the visual representation of the DAG by minimizing horizontal scrolling and better utilizing vertical space.

## Summary of Changes
tldr: construct pipeline "bottoms-up" instead of "top-down"
_Note_: I'd love the option to toggle the layout between the two options, but frankly "adding" features (vs modifying them) is a bit out of reach for me.

1. Initialization of Node Children Map:
> A new nodeChildren map was introduced to track the children of each node. This map helps in identifying leaf nodes and facilitates the bottom-up processing of the DAG.
> A nodeChildren map is created to keep track of each node's children.
```ts
const nodeChildren = new Map<number, number[]>();

itemsArray.forEach(item => {
  item.parentIds.forEach(pid => {
    if (!nodeChildren.has(pid)) {
      nodeChildren.set(pid, []);
    }
    nodeChildren.get(pid).push(item.stepId);
  });
});
```
2. Assignment of Levels:
> The function assignLevels was created to recursively assign levels to each node starting from the leaf nodes. This function ensures that each node is placed at a level based on the longest path from it to any leaf node.
> The assignLevels function is defined to recursively assign levels to each node. Starting from the leaf nodes, it assigns levels to parent nodes, ensuring that all nodes are positioned correctly.
```ts
const assignLevels = (item, currentLevel) => {
  const existingLevel = nodeLevels.get(item.stepId);
  if (existingLevel === undefined || existingLevel < currentLevel) {
    nodeLevels.set(item.stepId, currentLevel);
    const parents = itemsArray.filter(i => item.parentIds.includes(i.stepId));
    parents.forEach(parent => {
      assignLevels(parent, currentLevel + 1);
    });
  }
};
```
3. Sorting Nodes by Level:
> After assigning levels, nodes are sorted by their levels. The maxLevel is calculated to position nodes correctly from bottom to top. Nodes are then added to the result array based on their calculated level.
> Leaf nodes are identified (nodes without children in the nodeChildren map), and levels are assigned starting from these nodes.
```ts
itemsArray.forEach(item => {
  if (!nodeChildren.has(item.stepId)) {
    assignLevels(item, 0);
  }
});
```
> Nodes are sorted by their levels, and the maximum level is calculated. Nodes are then positioned in the result array based on their level, ensuring a bottom-up layout.
```ts
const maxLevel = Math.max(...nodeLevels.values());
itemsArray.forEach(item => {
  const level = maxLevel - nodeLevels.get(item.stepId);
  if (!result[level]) {
    result[level] = [];
  }
  result[level].push(item);
});
```
By implementing these changes, the DAG layout algorithm now ensures that all final steps are positioned at the bottom level, building upwards to improve the visual representation and reduce horizontal scrolling.

## Before
<img width="628" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/0a8462ef-028c-4061-813c-f74d58a89210">
<img width="614" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/da33e3aa-046f-45ad-9162-15981aa46a55">
<img width="656" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/66b8b26d-39da-4494-8e15-afef78a490b0">

## After

<img width="617" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/e7ce347a-5242-4d31-acb4-5f39d77ed584">
<img width="777" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/6e506a0e-ee92-4827-afe5-3952548bd7ca">
<img width="783" alt="image" src="https://github.com/mathematicalmichael/clearml-web/assets/40366263/5a84dc87-9f94-40b5-805b-e0e63fc7c0bb">

> for the pipelines I've been looking at all day for the past few months, "bottoms-up" just makes so much more sense, as the "results" are all towards the bottom of the execution flow.